### PR TITLE
Ensure that secrets can't be added more than once per second.

### DIFF
--- a/mozsvc/tests/test_secrets.py
+++ b/mozsvc/tests/test_secrets.py
@@ -4,6 +4,8 @@
 import unittest2
 import tempfile
 import os
+import time
+import itertools
 
 from mozsvc.secrets import Secrets
 
@@ -27,9 +29,16 @@ class TestSecrets(unittest2.TestCase):
     def test_read_write(self):
         secrets = Secrets()
 
-        secrets.add('phx23456')
-        secrets.add('phx23456')
-        secrets.add('phx23')
+        # We can only add one secret per second to the file, since
+        # they are timestamped to 1s resolution.  Fake it.
+        real_time = time.time
+        time.time = itertools.count(int(real_time())).next
+        try:
+            secrets.add('phx23456')
+            secrets.add('phx23456')
+            secrets.add('phx23')
+        finally:
+            time.time = real_time
 
         phx23456_secrets = secrets.get('phx23456')
         self.assertEqual(len(secrets.get('phx23456')), 2)


### PR DESCRIPTION
The secrets file format only supports one-second resolution, so if you add secrets in quick succession they can get saved/loaded in the wrong order.  This was causing sporadic test failures.

This patch causes secrets.add() to fail if you call it in quick succession.  Seemed safer than trying to futz the secrets so it succeeds in this never-going-to-happen-in-production case.
