### PR TITLE
Add a tween to log uncaught exceptions.

### DIFF
--- a/mozsvc/tweens.py
+++ b/mozsvc/tweens.py
@@ -2,14 +2,27 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import sys
 import traceback
 import simplejson as json
 
-from pyramid.httpexceptions import HTTPServiceUnavailable
+from pyramid.httpexceptions import WSGIHTTPException, HTTPServiceUnavailable
 
-from mozsvc import logger
+import mozsvc
 from mozsvc.exceptions import BackendError
 from mozsvc.middlewares import create_hash
+
+
+def get_logger(request):
+    """Get the logger object to use for the given request.
+
+    This will return a metlog client if one is attached to the request,
+    or the default mozsvc.logger object if not.
+    """
+    logger = request.registry.get("metlog")
+    if logger is None:
+        logger = mozsvc.logger
+    return logger
 
 
 def catch_backend_errors(handler, registry):
@@ -22,6 +35,7 @@ def catch_backend_errors(handler, registry):
         try:
             return handler(request)
         except BackendError as err:
+            logger = get_logger(request)
             err_info = str(err)
             err_trace = traceback.format_exc()
             try:
@@ -48,6 +62,34 @@ def catch_backend_errors(handler, registry):
     return catch_backend_errors_tween
 
 
+def log_uncaught_exceptions(handler, registry):
+    """Tween to log all uncaught exceptions via metlog."""
+
+    def log_uncaught_exceptions_tween(request):
+        try:
+            return handler(request)
+        except WSGIHTTPException:
+            raise
+        except Exception:
+            logger = get_logger(request)
+            # We don't want to write arbitrary user-provided data into the
+            # the logfiles.  For example, the sort of data that might show
+            # up in the payload of a ValueError exception.
+            # Format the traceback using standard printing, but use repr()
+            # on the exception value itself to avoid this issue.
+            exc_type, exc_val, exc_tb = sys.exc_info()
+            lines = ["Uncaught exception while processing request:\n"]
+            lines.append("%s %s\n" % (request.method, request.path_url))
+            lines.extend(traceback.format_tb(exc_tb))
+            lines.append("%r\n" % (exc_type,))
+            lines.append("%r\n" % (exc_val,))
+            logger.exception("".join(lines))
+            raise
+
+    return log_uncaught_exceptions_tween
+
+
 def includeme(config):
     """Include all the mozsvc tweens into the given config."""
     config.add_tween("mozsvc.tweens.catch_backend_errors")
+    config.add_tween("mozsvc.tweens.log_uncaught_exceptions")


### PR DESCRIPTION
This tween is currently used in server-aitc for logging uncaught exceptions, maybe we should pull it out into mozsvc?
