### PR TITLE
Commit the configurator when running functional tests.

### DIFF
--- a/mozsvc/tests/support.py
+++ b/mozsvc/tests/support.py
@@ -120,6 +120,7 @@ class FunctionalTestCase(TestCase):
             self.distant = True
             self.host_url = test_remote
             application = WSGIProxyApp(test_remote)
+            self.config.commit()
 
         host_url = urlparse.urlparse(self.host_url)
         self.app = TestApp(application, extra_environ={


### PR DESCRIPTION
The FunctionalTestCase class commits the configurator (implicity via make_wsgi_app) when it's running against an in-memory configuration, but not when it's running against a live server.  It should do it consistently across both branches, so that it can be used to e.g. look up the appropriate authentication policy classes.

@rafrombrc r?
