### PR TITLE
Compatability with latest cornice release.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requires = ['pyramid', 'simplejson', 'cef']
 
 tests_requires = requires + [
             'pyramid_macauth', 'tokenlib', 'macauthlib>=0.3.0',
-            'cornice', 'wsgiproxy', 'unittest2']
+            'cornice>=0.10', 'wsgiproxy', 'unittest2']
 
 extras_require = {
     'metlog': ['metlog-py>=0.9.1'],


### PR DESCRIPTION
This is my attempt to fix Issue #24, brining MetricsService up-to-date with latest cornice refactoring:
- We now need to specify the "depth" parameter for use by venusian
- Cornice no longer returns the decorated view function, but simply registers it with pyramid and returns the original function.  For MetricsService we need to actually return the decorated function so I have overridden the "decorate" method accordingly.

@ametaireau r?
