### PR TITLE
Bug 1365328 - Gracefully handle non-utf8 URL paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
- - "2.6"
  - "2.7"
 
 notifications:

--- a/mozsvc/metrics.py
+++ b/mozsvc/metrics.py
@@ -21,7 +21,7 @@ import logging
 import functools
 
 import pyramid.threadlocal
-from pyramid.events import NewRequest
+from pyramid.events import ContextFound
 
 
 logger = logging.getLogger("mozsvc.metrics")
@@ -195,4 +195,7 @@ def new_request_listener(event):
 
 def includeme(config):
     """Include the mozsvc metrics hooks into the given config."""
-    config.add_subscriber(new_request_listener, NewRequest)
+    # The metrics-gathering code assumes a well-formed request,
+    # so it's only safe to add it after pyramid has done a certain
+    # amount of processing and view resolution.
+    config.add_subscriber(new_request_listener, ContextFound)

--- a/mozsvc/tests/test_views.py
+++ b/mozsvc/tests/test_views.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# ***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+# ***** END LICENSE BLOCK *****
+
+import unittest
+
+import pyramid.testing
+
+from mozsvc.tests.support import make_request
+
+
+class TestUtil(unittest.TestCase):
+
+    def setUp(self):
+        self.app = None
+        self.config = pyramid.testing.setUp()
+        self.config.include("mozsvc")
+
+    def tearDown(self):
+        pyramid.testing.tearDown()
+
+    def _make_request(self, *args, **kwds):
+        return make_request(self.config, *args, **kwds)
+
+    def _do_request(self, *args, **kwds):
+        if self.app is None:
+            self.app = self.config.make_wsgi_app()
+        req = self._make_request(*args, **kwds)
+        return self.app.handle_request(req)
+
+    def test_heartbeat_view(self):
+        r = self._do_request("/__heartbeat__")
+        self.assertEquals(r.status_int, 200)
+        self.assertEquals(r.body, "OK")
+
+    def test_non_utf8_url_path(self):
+        r = self._do_request("/test/\xFF/path")
+        self.assertEquals(r.status_int, 404)

--- a/mozsvc/views.py
+++ b/mozsvc/views.py
@@ -4,11 +4,17 @@
 # file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 # ***** END LICENSE BLOCK *****
-""" Cornice default views/.
-"""
+
 from pyramid.view import view_config
+from pyramid.exceptions import URLDecodeError
+from pyramid.httpexceptions import HTTPNotFound
 
 
 @view_config(route_name='heartbeat', renderer='string')
 def hearbeat(request):
     return 'OK'
+
+
+@view_config(context=URLDecodeError)
+def invalid_url_view(request):
+    return HTTPNotFound()


### PR DESCRIPTION
In https://bugzilla.mozilla.org/show_bug.cgi?id=1365328 we discovered that the tokenserver returns a "500 server error" when requesting a URL with invalid utf8 in the path component, such as "/%FF".  There's no harm in erroring out, but let's do it cleanly so that the server logs aren't filled with spurious 500 errors.

This adds an exception view to convert the exception into a 404, which appears to be the recommended approach for pyramid.  It also slightly adjusts the metrics-gathering code, which assumes that the path can be converted to a string, and which was previously running before pyramid got a chance to route-match the path and detect it as invalid.

@Natim r?