### PR TITLE
Testing the memcached client on Travis.ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 
 python:
- - "2.7"
+  - "2.7"
+
+services:
+  - memcached
 
 notifications:
   email:
@@ -14,7 +17,7 @@ notifications:
 
 install:
   - pip install flake8
-  - python setup.py develop
+  - CFLAGS="-Wno-error=write-strings" pip install .[memcache]
 
 script:
   - flake8 ./mozsvc

--- a/mozsvc/middlewares.py
+++ b/mozsvc/middlewares.py
@@ -104,7 +104,7 @@ class CatchErrorMiddleware(object):
     def __call__(self, environ, start_response):
         try:
             return self.app(environ, start_response)
-        except:
+        except Exception:
             err = traceback.format_exc()
             hash = create_hash(err)
             self.logger.error(hash)

--- a/mozsvc/storage/mcclient.py
+++ b/mozsvc/storage/mcclient.py
@@ -75,11 +75,11 @@ class MemcachedClient(object):
                 # disconnect so that it will be removed from the pool.
                 try:
                     yield mc
-                except (EnvironmentError, RuntimeError), err:
+                except (EnvironmentError, RuntimeError) as err:
                     if mc is not None:
                         mc.disconnect()
                     raise
-        except (EnvironmentError, RuntimeError), err:
+        except (EnvironmentError, RuntimeError) as err:
             err = traceback.format_exc()
             logger.error(err)
             raise BackendError(str(err))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ WSGIProxy
 pyramid_hawkauth
 tokenlib
 hawkauthlib
-umemcache
+umemcache>=1.3
 gunicorn
 gevent
 konfig


### PR DESCRIPTION
For testing the memcached client retrieving an empty value will fail.
To avoid this we set a value first.

Some statements have been updated to make flake8 happy and the transition to Python 3 easier.
The requirements file now has the same constraint as setup.py.